### PR TITLE
Fix label issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fisgeci-forked-react-native-chart-kit",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "devDependencies": {
     "@types/react-native": "^0.62.13",
     "babel-eslint": "10.x",

--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -225,7 +225,6 @@ export interface LineChartProps extends AbstractChartProps {
   ) => ReactNode;
 
   paddingLeft: number;
-  paddingRight: number;
 }
 
 type LineChartState = {

--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -223,6 +223,9 @@ export interface LineChartProps extends AbstractChartProps {
   renderScrollableDotView?: <T extends ScrollableDotView>(
     ref: RefObject<T>
   ) => ReactNode;
+
+  paddingLeft: number;
+  paddingRight: number;
 }
 
 type LineChartState = {
@@ -831,7 +834,8 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
       formatXLabel = xLabel => xLabel,
       segments,
       transparent = false,
-      chartConfig
+      chartConfig,
+      paddingLeft = 64
     } = this.props;
 
     const { scrollableDotHorizontalOffset } = this.state;
@@ -839,11 +843,17 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     const {
       borderRadius = 0,
       paddingTop = 16,
-      paddingRight = 64,
       margin = 0,
       marginRight = 0,
       paddingBottom = 0
     } = style;
+
+    /* TODO - Rename all the padding right in all functions to padding left
+       Currently if we want to shift the chart to the right we are applying right padding instead of left
+       this is the inverse of what we actually want.
+       So for now we assign a temporary paddingRight variable till we rename the below usages as well
+     */
+    const paddingRight = paddingLeft;
 
     const scrollAnimatedEvent = event => {
       const perData = width / this.numberOfVisibleDots;


### PR DESCRIPTION
Add props to the AbstractChartConfig instead of getting them from the style property.

This was causing the chart to be squished from both sides.
Also add todo for wrong naming of variables